### PR TITLE
Fixes #30304 - improve logging and PEM cert chain

### DIFF
--- a/app/controllers/api/v2/webhooks_controller.rb
+++ b/app/controllers/api/v2/webhooks_controller.rb
@@ -29,7 +29,7 @@ module Api
           param :webhook_template_id, :identifier
           param :enabled, :boolean
           param :verify_ssl, :boolean
-          param :ssl_ca_file, String, N_('X509 Certification Authorities')
+          param :ssl_ca_certs, String, N_('X509 Certification Authorities concatenated in PEM format')
           param :user, String
           param :password, String
         end

--- a/app/controllers/concerns/foreman_webhooks/controller/parameters/webhook.rb
+++ b/app/controllers/concerns/foreman_webhooks/controller/parameters/webhook.rb
@@ -11,7 +11,7 @@ module ForemanWebhooks
             Foreman::ParameterFilter.new(::Webhook).tap do |filter|
               filter.permit :name, :target_url, :webhook_template_id, :event,
                             :http_method, :http_content_type, :enabled,
-                            :verify_ssl, :ssl_ca_file, :user, :password
+                            :verify_ssl, :ssl_ca_certs, :user, :password
             end
           end
         end

--- a/app/views/foreman_webhooks/webhook_templates/webhook_template_-_payload_default.erb
+++ b/app/views/foreman_webhooks/webhook_templates/webhook_template_-_payload_default.erb
@@ -3,9 +3,9 @@ name: Webhook Template - Payload Default
 description: This template is used to define default content of payload for a webhook.
 snippet: false
 model: WebhookTemplate
-%>
+-%>
 <%=
 payload({
   id: @object.id
 })
-%>
+-%>

--- a/app/views/webhooks/_form.html.erb
+++ b/app/views/webhooks/_form.html.erb
@@ -25,9 +25,9 @@
 
   <%= checkbox_f f, :enabled, help_inline: _('If unchecked, the webhook will be inactive') %>
   <%= checkbox_f f, :verify_ssl, help_inline: _("Uncheck this option to disable validation of the receiver's SSL certificate") %>
-  <%= textarea_f f, :ssl_ca_file, label: _('X509 Certification Authorities'),
-                                  size: 'col-md-8',
-                                  placeholder: _("Optionally provide a CA, or a correctly ordered CA chain to verify the receiver's SSL certificate.") %>
+  <%= textarea_f f, :ssl_ca_certs, label: _('X509 Certification Authorities'),
+    size: 'col-md-8', rows: 10,
+    placeholder: _("Optional CAs in PEM format concatenated to verify the receiver's SSL certificate.") %>
 
   <%= submit_or_cancel f %>
 <% end %>

--- a/db/migrate/20201014115147_rename_ca_file_column.rb
+++ b/db/migrate/20201014115147_rename_ca_file_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameCaFileColumn < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :webhooks, :ssl_ca_file, :ssl_ca_certs
+  end
+end


### PR DESCRIPTION
This logs rendered templates into Foreman BLOB logger (when enabled). Also improves logging a bit also writing return code.

During testing I realized that SSL X509 handling was written via temp file, this is an overlook. We need to support one or more X509 PEM CAs, this needs to be edited in a textarea (I made it little big bigger) and CA bundle must be created and passed into Net::HTTP client to verify the chain.

I also fix one fatal bug when event parameter was deleted from the parameter for no reason. When the same event was subscribed twice or more, subsequent calls were suffering from nil pointer exception.