### PR TITLE
Fixes #31301 - arbitrary HTTP headers

### DIFF
--- a/app/controllers/api/v2/webhooks_controller.rb
+++ b/app/controllers/api/v2/webhooks_controller.rb
@@ -32,6 +32,7 @@ module Api
           param :ssl_ca_certs, String, N_('X509 Certification Authorities concatenated in PEM format')
           param :user, String
           param :password, String
+          param :http_headers, String
         end
       end
 

--- a/app/controllers/concerns/foreman_webhooks/controller/parameters/webhook.rb
+++ b/app/controllers/concerns/foreman_webhooks/controller/parameters/webhook.rb
@@ -9,9 +9,18 @@ module ForemanWebhooks
         class_methods do
           def webhook_params_filter
             Foreman::ParameterFilter.new(::Webhook).tap do |filter|
-              filter.permit :name, :target_url, :webhook_template_id, :event,
-                            :http_method, :http_content_type, :enabled,
-                            :verify_ssl, :ssl_ca_certs, :user, :password
+              filter.permit :name,
+                            :target_url,
+                            :webhook_template_id,
+                            :event,
+                            :http_method,
+                            :http_content_type,
+                            :enabled,
+                            :verify_ssl,
+                            :ssl_ca_certs,
+                            :user,
+                            :password,
+                            :http_headers
             end
           end
         end

--- a/app/jobs/foreman_webhooks/deliver_webhook_job.rb
+++ b/app/jobs/foreman_webhooks/deliver_webhook_job.rb
@@ -6,7 +6,13 @@ module ForemanWebhooks
 
     def perform(options)
       webhook = Webhook.unscoped.find_by(id: options[:webhook_id])
-      WebhookService.new(webhook: webhook, event_name: options[:event_name], payload: options[:payload]).execute
+      WebhookService.new(
+        webhook: webhook,
+        headers: options[:headers],
+        url: options[:url],
+        event_name: options[:event_name],
+        payload: options[:payload]
+      ).execute
     end
 
     def webhook_id

--- a/app/lib/foreman_webhooks/renderer/scope/webhook_template.rb
+++ b/app/lib/foreman_webhooks/renderer/scope/webhook_template.rb
@@ -30,10 +30,6 @@ module ForemanWebhooks
           hash.merge!(@defaults) if with_defaults
           hash.to_json
         end
-
-        def allowed_helpers
-          @allowed_helpers ||= super + %i[payload]
-        end
       end
     end
   end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -33,7 +33,6 @@ class Webhook < ApplicationRecord
   validates :target_url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]),
                                    message: _('URL must be valid and schema must be one of: %s') % 'http, https' }
   validates :http_method, inclusion: { in: ALLOWED_HTTP_METHODS }
-  validate :http_headers_json
 
   belongs_to :webhook_template, foreign_key: :webhook_template_id
 
@@ -101,14 +100,6 @@ class Webhook < ApplicationRecord
 
   private
 
-  def http_headers_json
-    return if http_headers.blank?
-
-    JSON.parse(http_headers)
-  rescue JSON::ParserError => e
-    errors[:http_headers] << "is not valid JSON: #{e}"
-  end
-
   def set_default_template
     self.webhook_template = WebhookTemplate.find_by!(name: DEFAULT_PAYLOAD_TEMPLATE)
   end
@@ -144,7 +135,7 @@ class Webhook < ApplicationRecord
   end
 
   def rendered_targed_url(event_name, payload)
-    source = Foreman::Renderer::Source::String.new(name: 'HTTP header template', content: target_url)
+    source = Foreman::Renderer::Source::String.new(name: 'HTTP target URL template', content: target_url)
     render_source(source, event_name, payload)
   end
 end

--- a/app/services/foreman_webhooks/webhook_service.rb
+++ b/app/services/foreman_webhooks/webhook_service.rb
@@ -32,8 +32,8 @@ module ForemanWebhooks
                                     password: webhook.password,
                                     content_type: webhook.http_content_type,
                                     headers: headers,
-                                    ca_string: webhook.verify_ssl?,
-                                    ca_verify: webhook.ca_certs_store,
+                                    ca_verify: webhook.verify_ssl?,
+                                    ca_string: webhook.ca_certs_store,
                                     follow_redirects: true)
 
       status = case response.code.to_i

--- a/app/services/foreman_webhooks/webhook_service.rb
+++ b/app/services/foreman_webhooks/webhook_service.rb
@@ -2,19 +2,39 @@
 
 module ForemanWebhooks
   class WebhookService
-    attr_accessor :webhook, :event_name, :payload
+    attr_accessor :webhook, :event_name, :payload, :rendered_headers, :rendered_url
 
     delegate :logger, to: Rails
 
-    def initialize(webhook:, event_name:, payload:)
+    def initialize(webhook:, event_name:, payload:, headers:, url:)
       @webhook = webhook
       @event_name = event_name
       @payload = payload
+      @rendered_headers = headers
+      @rendered_url = url
     end
 
     def execute
-      Foreman::Logging.blob("Webhook payload for event #{event_name}", payload)
-      response = request(webhook, payload)
+      logger.info("Performing '#{webhook.name}' webhook request for event '#{event_name}'")
+      Foreman::Logging.blob("Payload for '#{event_name}'", payload)
+      headers = {}
+      begin
+        headers = JSON.parse(rendered_headers)
+      rescue StandardError => e
+        logger.warn("Could not parse HTTP headers JSON, ignoring: #{e}")
+        logger.debug("Headers: #{rendered_headers}")
+      end
+
+      response = self.class.request(url: webhook.target_url,
+                                    payload: payload,
+                                    http_method: webhook.http_method,
+                                    user: webhook.user,
+                                    password: webhook.password,
+                                    content_type: webhook.http_content_type,
+                                    headers: headers,
+                                    ca_string: webhook.verify_ssl?,
+                                    ca_verify: webhook.ca_certs_store,
+                                    follow_redirects: true)
 
       status = case response.code.to_i
                when 400..599
@@ -38,24 +58,22 @@ module ForemanWebhooks
       }
     end
 
-    private
+    def self.request(url:, payload: '', http_method: :GET, user: nil, password: nil, content_type: 'application/json', headers: {}, ca_string: nil, ca_verify: false, follow_redirects: true, redirect_limit: 3)
+      uri = URI.parse(url)
 
-    def request(webhook, payload)
-      uri = URI.parse(webhook.target_url)
-
-      http_method = Object.const_get("Net::HTTP::#{webhook.http_method.capitalize}")
-
-      request = http_method.new(uri.request_uri)
-      request.basic_auth(webhook.user, webhook.password) if webhook.user && webhook.password
-      request['Content-Type'] = webhook.http_content_type
+      request = Object.const_get("Net::HTTP::#{http_method.to_s.capitalize}").new(uri.request_uri)
+      request.basic_auth(user, password) if user && password
+      request['Content-Type'] = content_type
       request['X-Request-Id'] = ::Logging.mdc['request'] || SecureRandom.uuid
       request['X-Session-Id'] = ::Logging.mdc['session'] || SecureRandom.uuid
+      headers.each_pair do |key, value|
+        request[key.to_s] = value.to_s
+      end
       request.body = payload
 
-      logger.info("#{webhook.http_method.to_s.upcase} request for webhook #{webhook.name}:")
-      logger.debug("Target: #{uri}")
-      logger.debug("Headers: #{request.to_hash.inspect}")
-      logger.debug("Body: #{request.body.inspect}")
+      Rails.logger.debug("Webhook #{http_method.to_s.upcase} request: #{uri}")
+      Rails.logger.debug("Headers: #{request.to_hash.inspect}")
+      Rails.logger.debug("Body: #{request.body.inspect}")
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.open_timeout = Setting[:proxy_request_timeout]
@@ -63,10 +81,31 @@ module ForemanWebhooks
       http.ssl_timeout = Setting[:proxy_request_timeout]
       if uri.scheme == 'https'
         http.use_ssl = true
-        http.verify_mode = webhook.verify_ssl? ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
-        http.cert_store = webhook.ca_certs_store
+        http.verify_mode = ca_verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+        http.cert_store = ca_string if ca_string
       end
-      http.request(request)
+      http.request(request) do |response|
+        case response
+        when Net::HTTPRedirection then
+          new_location = response['location']
+          Rails.logger.debug "Redirected to #{new_location} (redirects left: #{redirect_limit})"
+          raise(::Foreman::Exception, N_(format('Too many HTTP redirects when calling %{uri}', uri: uri, code: response.code))) if redirect_limit <= 0
+
+          self.request(url: new_location,
+                       payload: payload,
+                       http_method: http_method,
+                       user: user,
+                       password: password,
+                       content_type: content_type,
+                       ca_string: ca_string,
+                       ca_verify: ca_verify,
+                       headers: headers,
+                       follow_redirects: follow_redirects,
+                       redirect_limit: redirect_limit - 1)
+        else
+          response
+        end
+      end
     end
   end
 end

--- a/app/views/api/v2/webhooks/show.json.rabl
+++ b/app/views/api/v2/webhooks/show.json.rabl
@@ -4,7 +4,14 @@ object @webhook
 
 extends 'api/v2/webhooks/main'
 
-attributes :event, :http_method, :http_content_type, :verify_ssl
+attributes :target_url,
+           :event,
+           :http_method,
+           :http_content_type,
+           :enabled,
+           :verify_ssl,
+           # TODO: how do I break these into individual fields?
+           :http_headers
 
 child :webhook_template do
   extends 'api/v2/webhook_templates/base'

--- a/app/views/api/v2/webhooks/show.json.rabl
+++ b/app/views/api/v2/webhooks/show.json.rabl
@@ -10,7 +10,6 @@ attributes :target_url,
            :http_content_type,
            :enabled,
            :verify_ssl,
-           # TODO: how do I break these into individual fields?
            :http_headers
 
 child :webhook_template do

--- a/app/views/foreman_webhooks/webhook_templates/ansible_tower_-_host_in_inventory.erb
+++ b/app/views/foreman_webhooks/webhook_templates/ansible_tower_-_host_in_inventory.erb
@@ -1,0 +1,18 @@
+<%#
+name: Ansible Tower - Host in Inventory
+description: Create/update a host with associated inventory in Ansible Tower.
+snippet: false
+model: WebhookTemplate
+-%>
+<%#
+  Create URL: https://tower/api/v2/hosts
+  Update/Delete URL: https://tower/api/v2/hosts/$HOST_ID
+-%>
+{
+  "name": "<%= @object.name %>",
+  "description": "Created via Foreman Webhook",
+  "inventory": <%= @object.host_param('ansible_tower_inventory_id') || 1 %>,
+  "enabled": true,
+  "instance_id": "",
+  "variables": ""
+}

--- a/app/views/foreman_webhooks/webhook_templates/ansible_tower_-_host_in_inventory.erb
+++ b/app/views/foreman_webhooks/webhook_templates/ansible_tower_-_host_in_inventory.erb
@@ -8,11 +8,13 @@ model: WebhookTemplate
   Create URL: https://tower/api/v2/hosts
   Update/Delete URL: https://tower/api/v2/hosts/$HOST_ID
 -%>
-{
-  "name": "<%= @object.name %>",
-  "description": "Created via Foreman Webhook",
-  "inventory": <%= @object.host_param('ansible_tower_inventory_id') || 1 %>,
-  "enabled": true,
-  "instance_id": "",
-  "variables": ""
-}
+<%=
+  payload({
+    "name": @object.name,
+    "description": "Created via Foreman Webhook",
+    "inventory": @object.host_param('ansible_tower_inventory_id') || 1,
+    "enabled": true,
+    "instance_id": "",
+    "variables": ""
+  }, with_defaults: false)
+-%>

--- a/app/views/foreman_webhooks/webhook_templates/empty_payload.erb
+++ b/app/views/foreman_webhooks/webhook_templates/empty_payload.erb
@@ -1,0 +1,6 @@
+<%#
+name: Empty Payload
+description: Useful for Shellhooks which only takes arguments via HTTP parameters.
+snippet: false
+model: WebhookTemplate
+-%>

--- a/app/views/webhooks/_form.html.erb
+++ b/app/views/webhooks/_form.html.erb
@@ -29,5 +29,9 @@
     size: 'col-md-8', rows: 10,
     placeholder: _("Optional CAs in PEM format concatenated to verify the receiver's SSL certificate.") %>
 
+  <%= textarea_f f, :http_headers, label: _('Optional HTTP headers as JSON (ERB allowed)'),
+    size: 'col-md-8', rows: 6,
+    placeholder: "{\n\"X-Shellhook-Arg-1\": \"value\"\n}" %>
+
   <%= submit_or_cancel(f, false, { react_cancel_button: true, cancel_path: '/webhooks' }) %>
 <% end %>

--- a/db/migrate/20201109135301_add_http_headers.rb
+++ b/db/migrate/20201109135301_add_http_headers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddHttpHeaders < ActiveRecord::Migration[6.0]
+  def change
+    # HTTP headers stored as JSON: {"header_name": "value"}
+    add_column :webhooks, :http_headers, :text, null: true
+  end
+end

--- a/lib/foreman_webhooks/engine.rb
+++ b/lib/foreman_webhooks/engine.rb
@@ -61,6 +61,11 @@ module ForemanWebhooks
         menu :admin_menu, :webhook_templates, url_hash: { controller: :webhook_templates, action: :index },
                                               caption: N_('Webhook Templates'),
                                               parent: :administer_menu
+
+        # add helpers to safe-mode
+        allowed_template_helpers :payload
+
+        # subscribe to all events
         subscribe(/.event.foreman$/, ::ForemanWebhooks::EventSubscriber)
       end
     end

--- a/test/unit/foreman_webhooks/webhook_service_test.rb
+++ b/test/unit/foreman_webhooks/webhook_service_test.rb
@@ -14,7 +14,9 @@ module ForemanWebhooks
       WebhookService.new(
         webhook: webhook,
         event_name: event_name,
-        payload: payload_json
+        payload: payload_json,
+        headers: {},
+        url: webhook.target_url
       )
     end
 


### PR DESCRIPTION
For better Shellhooks plugin integration, we should allow passing arguments into scripts via X-Shellhook-Arg-N named HTTP headers. To allow that, we need to extend webhook with headers, the reasonable solution is to have one string/text SQL column with headers stored in JSON, which can be nicely presented to the user in the UI and CLI.

ERB will be enabled in the headers themselves as well as in URL for easier integration with backend services directly. This patch only prepares the field for #31299 if we choose to implement it.