### PR TITLE
Fixes #31514 - Make modal disappear on webhook delete

### DIFF
--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhookDeleteModal.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhookDeleteModal.js
@@ -18,7 +18,7 @@ const WebhookDeleteModal = ({ toDelete, onSuccess }) => {
       submitProps={{
         url: foremanUrl(`/api/v2/webhooks/${id}`),
         message: sprintf(__('Webhook %s was successfully deleted'), name),
-        onSuccess: { onSuccess },
+        onSuccess,
         submitBtnProps: {
           bsStyle: 'danger',
           btnText: __('Delete'),


### PR DESCRIPTION
@lzap, I guess this should be included within the first release, since the fix is pretty straightforward (some sort of mistype).