### PR TITLE
Fixes #32134 - client certificate support for smart proxy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ Metrics:
 Style/FormatStringToken:
   Enabled: false
 
+Layout/LineLength:
+  Enabled: false
+
 Lint/BooleanSymbol:
   Enabled: false
 

--- a/app/controllers/api/v2/webhooks_controller.rb
+++ b/app/controllers/api/v2/webhooks_controller.rb
@@ -34,6 +34,7 @@ module Api
           param :user, String
           param :password, String
           param :http_headers, String
+          param :proxy_authorization, :boolean, N_('Authorize with Foreman client certificate and validate smart-proxy CA from Settings')
         end
       end
 

--- a/app/controllers/concerns/foreman_webhooks/controller/parameters/webhook.rb
+++ b/app/controllers/concerns/foreman_webhooks/controller/parameters/webhook.rb
@@ -20,7 +20,8 @@ module ForemanWebhooks
                             :ssl_ca_certs,
                             :user,
                             :password,
-                            :http_headers
+                            :http_headers,
+                            :proxy_authorization
             end
           end
         end

--- a/app/views/webhooks/_form.html.erb
+++ b/app/views/webhooks/_form.html.erb
@@ -28,6 +28,7 @@
   <%= textarea_f f, :ssl_ca_certs, label: _('X509 Certification Authorities'),
     size: 'col-md-8', rows: 10,
     placeholder: _("Optional CAs in PEM format concatenated to verify the receiver's SSL certificate.") %>
+  <%= checkbox_f f, :proxy_authorization, help_inline: _("Authorize with Foreman client certificate and validate smart-proxy CA from Settings.") %>
 
   <%= textarea_f f, :http_headers, label: _('Optional HTTP headers as JSON (ERB allowed)'),
     size: 'col-md-8', rows: 6,

--- a/db/migrate/20210322144728_add_proxy_authorization_to_webhook.rb
+++ b/db/migrate/20210322144728_add_proxy_authorization_to_webhook.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProxyAuthorizationToWebhook < ActiveRecord::Migration[6.0]
+  def change
+    add_column :webhooks, :proxy_authorization, :boolean, null: false, default: false
+  end
+end

--- a/lib/tasks/foreman_webhooks_tasks.rake
+++ b/lib/tasks/foreman_webhooks_tasks.rake
@@ -44,6 +44,4 @@ end
 Rake::Task[:test].enhance ['test:foreman_webhooks']
 
 load 'tasks/jenkins.rake'
-if Rake::Task.task_defined?(:'jenkins:unit')
-  Rake::Task['jenkins:unit'].enhance ['test:foreman_webhooks', 'foreman_webhooks:rubocop']
-end
+Rake::Task['jenkins:unit'].enhance ['test:foreman_webhooks', 'foreman_webhooks:rubocop'] if Rake::Task.task_defined?(:'jenkins:unit')


### PR DESCRIPTION
This allows running webhooks over HTTPS against smart proxies running shellhooks.