### PR TITLE
Remove missing method from host job template

### DIFF
--- a/app/views/foreman_webhooks/webhook_templates/remote_execution_-_host_job.erb
+++ b/app/views/foreman_webhooks/webhook_templates/remote_execution_-_host_job.erb
@@ -18,4 +18,3 @@ model: WebhookTemplate
 # Task ended at <%= @object.task.ended_at %>
 # Task resulted with <%= @object.task.result %>
 # Task state <%= @object.task.state %>
-# Task action output <%= @object.task.action_output %>


### PR DESCRIPTION
This template does not even exist, I don't know how I ended up adding it, but it does not work.