### PR TITLE
Skip parsing headers when not set

### DIFF
--- a/app/services/foreman_webhooks/webhook_service.rb
+++ b/app/services/foreman_webhooks/webhook_service.rb
@@ -10,7 +10,13 @@ module ForemanWebhooks
       @webhook = webhook
       @event_name = event_name
       @payload = payload
-      @rendered_headers = headers
+      # rubocop:disable Lint/RedundantSafeNavigation
+      @rendered_headers = if headers&.is_a? Hash
+                            headers
+                          else
+                            {}
+                          end
+      # rubocop:enable Lint/RedundantSafeNavigation
       @rendered_url = url
     end
 
@@ -35,7 +41,7 @@ module ForemanWebhooks
       Foreman::Logging.blob("Payload for '#{event_name}'", payload)
       headers = {}
       begin
-        headers = JSON.parse(rendered_headers)
+        headers = JSON.parse(rendered_headers) unless rendered_headers.blank?
       rescue StandardError => e
         logger.warn("Could not parse HTTP headers JSON, ignoring: #{e}")
         logger.debug("Headers: #{rendered_headers}")


### PR DESCRIPTION
Looks like a warning is dropped into logs on every webhooks:

```
2021-12-07T19:11:55 [I|app|b7ad5c82] Performing 'Build Entered' webhook request for event 'build_entered.event.foreman'
2021-12-07T19:11:55 [W|app|b7ad5c82] Could not parse HTTP headers JSON, ignoring: no implicit conversion of nil into String
```

This should silence it, please test.