### PR TITLE
Fixes #30796 - Optimize webhook DB queries

### DIFF
--- a/app/models/webhook_template.rb
+++ b/app/models/webhook_template.rb
@@ -18,6 +18,7 @@ class WebhookTemplate < Template
   self.table_name = 'templates'
 
   before_destroy EnsureNotUsedBy.new(:webhooks)
+  after_commit :invalidate_cache, on: %i[update]
   has_many :webhooks, foreign_key: :webhook_template_id
 
   validates :name, uniqueness: true
@@ -59,5 +60,11 @@ class WebhookTemplate < Template
 
   def support_preview?
     false
+  end
+
+  private
+
+  def invalidate_cache
+    webhooks.each(&:invalidate_cache)
   end
 end


### PR DESCRIPTION
@lzap, here is my view on this ticket, please let me know what you think: on each event there is a at least 1 DB call to retrieve a webhook, but it's actually 2 due to webhook templates. If we have 5 webhooks configured to listen to 1 event then we make only 2 DB calls for 1 event each time it's fired (we fetch all the webhooks in one call + then one call for their templates). But If we have 5 webhooks configured to listen to 5 different events then it's 2 DB calls for each of those events. Thus, the more events we listen to, the more DB calls we do, obviously.

This solution tries to save into the cache all webhooks for a certain event, so each time we have an event we would make 2 DB calls one time instead of doing 2 DB calls each time an event is fired.

So, taking the previous example (5 webhooks to listen to 5 different events):
 - Currently it's 10 DB calls for each 5 events being fired, thus more than 10 DB calls for the whole time
 - With this fix it's only 10 DB calls for the whole time
 
 Worst scenario:
 - Without this fix, each time 2 DB calls for every event everytime an event is fired: 2 * N of events * M of fires = 2NM DB calls *at min*.
 - With this fix, 2 DB calls for every event only if a webhook or it's template is modified: 2 * N of events * M of fires = 2NM DB calls *at max*. Same number of DB calls, but with assumption that each webhook and/or its template will be modified after each fired event (which is unlikely to happen)
 
 Best scenario:
 - Without this fix, each time 2 DB calls for every event everytime an event is fired: 2 * N of events * M of fires = 2NM DB calls *at min*.
 - With this fix, only 2 DB calls for every event everytime an event **unless** all or any of the webhooks or their templates were modified: 2 * N of events = 2N DB calls *at max*.
 
 Side note: the cache invalidation happens for all the webhooks we stored for the event if one of those webhooks was updated/deleted. Also it happens if a new webhook was created for the same event. If a webhook was updated to subscribe to a different event then we invalidate cache for two events (the old one and the new one).
 
 We also invalidate cache if a webhook template was changed. Then we invalidate all stored webhooks (events) related to this template.