### PR TITLE
Fixes #34036 - Prevent eager loading for development

### DIFF
--- a/app/controllers/api/v2/webhooks_controller.rb
+++ b/app/controllers/api/v2/webhooks_controller.rb
@@ -25,8 +25,14 @@ module Api
           param :target_url, String, required: true
           param :http_method, Webhook::ALLOWED_HTTP_METHODS
           param :http_content_type, String
-          events = Webhook.available_events.sort.map { |e| e.delete_suffix(Webhook::EVENT_POSTFIX) }
-          param :event, events, required: true
+          # If you need to have the list of the events documented, you can run:
+          # $ apipie:cache RAILS_ENV=production
+          if Rails.env.development?
+            param :event, String, required: true
+          else
+            events = Webhook.available_events.sort.map { |e| e.delete_suffix(Webhook::EVENT_POSTFIX) }
+            param :event, events, required: true
+          end
           param :webhook_template_id, :identifier
           param :enabled, :boolean
           param :verify_ssl, :boolean


### PR DESCRIPTION
When you try to generate apidocs in development mode, eager_load in all_obseervable_events in core will cause the process to fail. When building packages, we use production. But this creates unnecessary pain to engineers who try to generate apidocs locally when in development.

This patch tries to solve this problem. It might have some sideeffects for CLI, but I think it's less evil than blocking folks from what they are about to do.