### PR TITLE
Fixes #35867 - Fix default Katello templates

### DIFF
--- a/app/views/foreman_webhooks/webhook_templates/katello_-_promote.erb
+++ b/app/views/foreman_webhooks/webhook_templates/katello_-_promote.erb
@@ -20,4 +20,3 @@ model: WebhookTemplate
 # Task ended at <%= @object.task.ended_at %>
 # Task resulted with <%= @object.task.result %>
 # Task state <%= @object.task.state %>
-# Task action output <%= @object.task.action_output %>

--- a/app/views/foreman_webhooks/webhook_templates/katello_-_promote.erb
+++ b/app/views/foreman_webhooks/webhook_templates/katello_-_promote.erb
@@ -20,3 +20,4 @@ model: WebhookTemplate
 # Task ended at <%= @object.task.ended_at %>
 # Task resulted with <%= @object.task.result %>
 # Task state <%= @object.task.state %>
+# Task action output <%= @object.task.action_continuous_output %>

--- a/app/views/foreman_webhooks/webhook_templates/katello_-_publish.erb
+++ b/app/views/foreman_webhooks/webhook_templates/katello_-_publish.erb
@@ -21,4 +21,3 @@ model: WebhookTemplate
 # Task ended at <%= @object.task.ended_at %>
 # Task resulted with <%= @object.task.result %>
 # Task state <%= @object.task.state %>
-# Task action output <%= @object.task.action_output %>

--- a/app/views/foreman_webhooks/webhook_templates/katello_-_publish.erb
+++ b/app/views/foreman_webhooks/webhook_templates/katello_-_publish.erb
@@ -21,3 +21,4 @@ model: WebhookTemplate
 # Task ended at <%= @object.task.ended_at %>
 # Task resulted with <%= @object.task.result %>
 # Task state <%= @object.task.state %>
+# Task action output <%= @object.task.action_continuous_output %>

--- a/app/views/foreman_webhooks/webhook_templates/katello_-_repo_sync.erb
+++ b/app/views/foreman_webhooks/webhook_templates/katello_-_repo_sync.erb
@@ -24,3 +24,4 @@ model: WebhookTemplate
 # Task ended at <%= @object.task.ended_at %>
 # Task resulted with <%= @object.task.result %>
 # Task state <%= @object.task.state %>
+# Task action output <%= @object.task.action_continuous_output %>

--- a/app/views/foreman_webhooks/webhook_templates/katello_-_repo_sync.erb
+++ b/app/views/foreman_webhooks/webhook_templates/katello_-_repo_sync.erb
@@ -24,4 +24,3 @@ model: WebhookTemplate
 # Task ended at <%= @object.task.ended_at %>
 # Task resulted with <%= @object.task.result %>
 # Task state <%= @object.task.state %>
-# Task action output <%= @object.task.action_output %>


### PR DESCRIPTION
Rendering of template fails with undefined method `action_output`.