### PR TITLE
Fixes #32363 - Add test button

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -77,6 +77,16 @@ class Webhook < ApplicationRecord
     )
   end
 
+  def test(payload: nil)
+    ForemanWebhooks::WebhookService.new(
+      webhook: self,
+      headers: rendered_headers(event, {}),
+      url: rendered_targed_url(event, {}),
+      event_name: event,
+      payload: test_payload(payload || '')
+    ).execute
+  end
+
   def ca_certs_store
     store = OpenSSL::X509::Store.new
     if ssl_ca_certs.blank?
@@ -131,5 +141,11 @@ class Webhook < ApplicationRecord
   def rendered_targed_url(event_name, payload)
     source = Foreman::Renderer::Source::String.new(name: 'HTTP target URL template', content: target_url)
     render_source(source, event_name, payload)
+  end
+
+  def test_payload(payload)
+    return payload if payload.is_a?(String)
+
+    payload.to_json
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,9 @@ Rails.application.routes.draw do
         collection do
           get :events
         end
+        member do
+          post :test
+        end
       end
       resources :webhook_templates, except: %i[new edit] do
         member do

--- a/lib/foreman_webhooks/engine.rb
+++ b/lib/foreman_webhooks/engine.rb
@@ -32,7 +32,7 @@ module ForemanWebhooks
           permission :create_webhooks,  { webhooks: %i[new create],
                                           'api/v2/webhooks': [:create] }, resource_type: 'Webhook'
           permission :edit_webhooks,    { webhooks: %i[edit update],
-                                          'api/v2/webhooks': [:update] }, resource_type: 'Webhook'
+                                          'api/v2/webhooks': %i[update test] }, resource_type: 'Webhook'
           permission :destroy_webhooks, { webhooks: [:destroy],
                                           'api/v2/webhooks': [:destroy] }, resource_type: 'Webhook'
           permission :view_webhook_templates, { webhook_templates: %i[index show auto_complete_search preview export],

--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhookTestModal.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhookTestModal.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { sprintf, translate as __ } from 'foremanReact/common/I18n';
+import ForemanModal from 'foremanReact/components/ForemanModal';
+import ForemanForm from 'foremanReact/components/common/forms/ForemanForm';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { submitForm } from 'foremanReact/redux/actions/common/forms';
+import { useForemanModal } from 'foremanReact/components/ForemanModal/ForemanModalHooks';
+
+import ForemanFormikField from '../../../Webhooks/Components/WebhookForm/Components/ForemanFormikField';
+
+import {
+  WEBHOOK_TEST_MODAL_ID,
+  WEBHOOKS_API_PLAIN_PATH,
+} from '../../constants';
+
+import './WebhookModal.scss';
+
+const WebhookTestModal = ({ toTest }) => {
+  const dispatch = useDispatch();
+
+  const { id, name } = toTest;
+  const { setModalClosed: setTestModalClosed } = useForemanModal({
+    id: WEBHOOK_TEST_MODAL_ID,
+  });
+  const initialTestValues = {
+    payload: '',
+  };
+  const errorToast = error =>
+    sprintf(
+      __('Webhook test failed: %s'),
+      error?.response?.data?.error?.message
+    );
+
+  const handleSubmit = (values, actions) => {
+    dispatch(
+      submitForm({
+        url: foremanUrl(`${WEBHOOKS_API_PLAIN_PATH}/${id}/test`),
+        values: { ...values, controller: 'webhooks' },
+        item: 'WebhookTest',
+        message: sprintf(__('Webhook %s test was successful'), name),
+        method: 'post',
+        successCallback: () => actions.setSubmitting(false),
+        actions,
+        errorToast,
+        handleError: () => actions.setSubmitting(false),
+      })
+    );
+  };
+
+  return (
+    <ForemanModal
+      id={WEBHOOK_TEST_MODAL_ID}
+      title={`${__('Test')} ${name}`}
+      backdrop="static"
+      enforceFocus
+      className="webhooks-modal"
+    >
+      <p>
+        {sprintf(
+          __(
+            'You are about to test %s webhook.' +
+              '\n' +
+              'Please, note that this will not contain actual information or render the attached template.' +
+              '\n' +
+              'You can specify below a custom payload to test the webhook with.'
+          ),
+          name
+        )}
+      </p>
+      <ForemanForm
+        onSubmit={handleSubmit}
+        initialValues={initialTestValues}
+        onCancel={setTestModalClosed}
+      >
+        <ForemanFormikField
+          name="payload"
+          type="textarea"
+          label={__('Payload')}
+          labelHelp={__('Will be sent as is')}
+          placeholder="{&#13;&#10;id: 1,&#13;&#10;name: test&#13;&#10;}"
+          inputSizeClass="col-md-8"
+          rows={8}
+        />
+      </ForemanForm>
+    </ForemanModal>
+  );
+};
+
+WebhookTestModal.propTypes = {
+  toTest: PropTypes.object,
+};
+
+WebhookTestModal.defaultProps = {
+  toTest: {},
+};
+
+export default WebhookTestModal;

--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/Components/ActionButtons/ActionButton.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/Components/ActionButtons/ActionButton.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { ActionButtons } from 'foremanReact/components/common/ActionButtons/ActionButtons';
+
+export const ActionButton = ({ id, name, canDelete, webhookActions }) => {
+  const buttons = [];
+  if (canDelete) {
+    buttons.push({
+      title: __('Delete'),
+      action: {
+        onClick: () => webhookActions.deleteWebhook(id, name),
+        id: `webhook-delete-button-${id}`,
+      },
+    });
+  }
+  buttons.push({
+    title: __('Test webhook'),
+    action: {
+      onClick: () => webhookActions.testWebhook(id, name),
+      id: `webhook-test-button-${id}`,
+    },
+  });
+
+  return <ActionButtons buttons={buttons} />;
+};
+
+ActionButton.propTypes = {
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  name: PropTypes.string.isRequired,
+  canDelete: PropTypes.bool,
+  webhookActions: PropTypes.shape({
+    deleteWebhook: PropTypes.func,
+    testWebhook: PropTypes.func,
+  }).isRequired,
+};
+
+ActionButton.defaultProps = {
+  canDelete: false,
+};

--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/Components/Formatters/actionCellFormatter.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/Components/Formatters/actionCellFormatter.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { cellFormatter } from 'foremanReact/components/common/table';
+import { ActionButton } from '../ActionButtons/ActionButton';
+
+const actionCellFormatter = webhookActions => (
+  _,
+  { rowData: { id, name, canEdit, canDelete } }
+) =>
+  cellFormatter(
+    canEdit && (
+      <ActionButton
+        canDelete={canDelete}
+        id={id}
+        name={name}
+        webhookActions={webhookActions}
+      />
+    )
+  );
+
+export default actionCellFormatter;

--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/Components/Formatters/index.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/Components/Formatters/index.js
@@ -1,2 +1,3 @@
 export { default as enabledCellFormatter } from './enabledCellFormatter';
 export { default as nameToEditFormatter } from './nameToEditFormatter';
+export { default as actionCellFormatter } from './actionCellFormatter';

--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/WebhooksTable.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/WebhooksTable.js
@@ -10,6 +10,7 @@ import { useForemanModal } from 'foremanReact/components/ForemanModal/ForemanMod
 
 import WebhookDeleteModal from '../WebhookDeleteModal';
 import WebhookEditModal from '../WebhookEditModal';
+import WebhookTestModal from '../WebhookTestModal';
 import EmptyWebhooksTable from './Components/EmptyWebhooksTable';
 
 import createWebhooksTableSchema from './WebhooksTableSchema';
@@ -32,10 +33,11 @@ import {
 const WebhooksTable = ({
   fetchAndPush,
   toDelete,
-  onDeleteClick,
+  toTest,
   toEdit,
   onEditClick,
   reloadWithSearch,
+  webhookActions,
 }) => {
   const webhooks = useSelector(selectWebhooks);
   const page = useSelector(selectPage);
@@ -75,13 +77,14 @@ const WebhooksTable = ({
         }}
         onCancel={setEditModalClosed}
       />
+      <WebhookTestModal toTest={toTest} />
       <Table
         key="webhooks-table"
         columns={createWebhooksTableSchema(
           fetchAndPush,
           sort.by,
           sort.order,
-          onDeleteClick,
+          webhookActions,
           onEditClick
         )}
         rows={webhooks}
@@ -94,11 +97,12 @@ const WebhooksTable = ({
 
 WebhooksTable.propTypes = {
   fetchAndPush: PropTypes.func.isRequired,
-  onDeleteClick: PropTypes.func.isRequired,
   onEditClick: PropTypes.func.isRequired,
   toDelete: PropTypes.object.isRequired,
+  toTest: PropTypes.object.isRequired,
   toEdit: PropTypes.number.isRequired,
   reloadWithSearch: PropTypes.func.isRequired,
+  webhookActions: PropTypes.object.isRequired,
 };
 
 export default WebhooksTable;

--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/WebhooksTableSchema.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/WebhooksTableSchema.js
@@ -3,13 +3,12 @@ import {
   column,
   sortableColumn,
   headerFormatterWithProps,
-  deleteActionCellFormatter,
-  cellFormatter,
 } from 'foremanReact/components/common/table';
 
 import {
   enabledCellFormatter,
   nameToEditFormatter,
+  actionCellFormatter,
 } from './Components/Formatters';
 
 const sortControllerFactory = (apiCall, sortBy, sortOrder) => ({
@@ -24,7 +23,7 @@ const createWebhooksTableSchema = (
   apiCall,
   by,
   order,
-  onDeleteClick,
+  webhookActions,
   onEditClick
 ) => {
   const sortController = sortControllerFactory(apiCall, by, order);
@@ -41,7 +40,7 @@ const createWebhooksTableSchema = (
       'actions',
       __('Actions'),
       [headerFormatterWithProps],
-      [deleteActionCellFormatter(onDeleteClick), cellFormatter]
+      [actionCellFormatter(webhookActions)]
     ),
   ];
 };

--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/__tests__/WebhooksTable.test.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/__tests__/WebhooksTable.test.js
@@ -11,6 +11,7 @@ const props = {
   onDeleteClick: jest.fn(),
   setToDelete: jest.fn(),
   setToEdit: jest.fn(),
+  setToTest: jest.fn(),
   reloadWithSearch: jest.fn(),
   itemCount: 0,
   canCreate: true,
@@ -20,6 +21,7 @@ const props = {
     perPage: 20,
   },
   toDelete: {},
+  toTest: {},
   toEdit: 0,
 };
 

--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/__tests__/__snapshots__/WebhooksTable.test.js.snap
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/__tests__/__snapshots__/WebhooksTable.test.js.snap
@@ -10,6 +10,7 @@ exports[`WebhooksTable rendering should render when loading 1`] = `
   itemCount={0}
   onDeleteClick={[MockFunction]}
   onEditClick={[Function]}
+  onTestClick={[Function]}
   page={5}
   pagination={
     Object {
@@ -29,6 +30,13 @@ exports[`WebhooksTable rendering should render when loading 1`] = `
   }
   toDelete={Object {}}
   toEdit={0}
+  toTest={Object {}}
+  webhookActions={
+    Object {
+      "deleteWebhook": [Function],
+      "testWebhook": [Function],
+    }
+  }
 />
 `;
 
@@ -48,6 +56,7 @@ exports[`WebhooksTable rendering should render with error 1`] = `
   }
   onDeleteClick={[MockFunction]}
   onEditClick={[Function]}
+  onTestClick={[Function]}
   page={5}
   pagination={
     Object {
@@ -67,6 +76,13 @@ exports[`WebhooksTable rendering should render with error 1`] = `
   }
   toDelete={Object {}}
   toEdit={0}
+  toTest={Object {}}
+  webhookActions={
+    Object {
+      "deleteWebhook": [Function],
+      "testWebhook": [Function],
+    }
+  }
 />
 `;
 
@@ -80,6 +96,7 @@ exports[`WebhooksTable rendering should render with no data 1`] = `
   itemCount={0}
   onDeleteClick={[MockFunction]}
   onEditClick={[Function]}
+  onTestClick={[Function]}
   page={5}
   pagination={
     Object {
@@ -99,6 +116,13 @@ exports[`WebhooksTable rendering should render with no data 1`] = `
   }
   toDelete={Object {}}
   toEdit={0}
+  toTest={Object {}}
+  webhookActions={
+    Object {
+      "deleteWebhook": [Function],
+      "testWebhook": [Function],
+    }
+  }
 />
 `;
 
@@ -112,6 +136,7 @@ exports[`WebhooksTable rendering should render with webhooks 1`] = `
   itemCount={2}
   onDeleteClick={[MockFunction]}
   onEditClick={[Function]}
+  onTestClick={[Function]}
   page={5}
   pagination={
     Object {
@@ -150,5 +175,12 @@ exports[`WebhooksTable rendering should render with webhooks 1`] = `
   }
   toDelete={Object {}}
   toEdit={0}
+  toTest={Object {}}
+  webhookActions={
+    Object {
+      "deleteWebhook": [Function],
+      "testWebhook": [Function],
+    }
+  }
 />
 `;

--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/index.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/Components/WebhooksTable/index.js
@@ -7,6 +7,7 @@ import WebhooksTable from './WebhooksTable';
 import {
   WEBHOOK_DELETE_MODAL_ID,
   WEBHOOK_EDIT_MODAL_ID,
+  WEBHOOK_TEST_MODAL_ID,
 } from '../../../constants';
 
 const WrappedWebhooksTable = props => {
@@ -18,7 +19,11 @@ const WrappedWebhooksTable = props => {
     id: WEBHOOK_EDIT_MODAL_ID,
   });
 
-  const { setToDelete, setToEdit, ...rest } = props;
+  const { setModalOpen: setTestModalOpen } = useForemanModal({
+    id: WEBHOOK_TEST_MODAL_ID,
+  });
+
+  const { setToDelete, setToEdit, setToTest, ...rest } = props;
 
   const onDeleteClick = rowData => {
     setToDelete(rowData);
@@ -30,10 +35,25 @@ const WrappedWebhooksTable = props => {
     setEditModalOpen();
   };
 
+  const onTestClick = rowData => {
+    setToTest(rowData);
+    setTestModalOpen();
+  };
+
+  const webhookActions = {
+    deleteWebhook: (id, name) => {
+      onDeleteClick({ id, name });
+    },
+    testWebhook: (id, name) => {
+      onTestClick({ id, name });
+    },
+  };
+
   return (
     <WebhooksTable
-      onDeleteClick={onDeleteClick}
       onEditClick={onEditClick}
+      onTestClick={onTestClick}
+      webhookActions={webhookActions}
       {...rest}
     />
   );
@@ -42,6 +62,7 @@ const WrappedWebhooksTable = props => {
 WrappedWebhooksTable.propTypes = {
   setToDelete: PropTypes.func.isRequired,
   setToEdit: PropTypes.func.isRequired,
+  setToTest: PropTypes.func.isRequired,
 };
 
 export default WrappedWebhooksTable;

--- a/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/WebhooksIndexPage.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/WebhooksIndexPage/WebhooksIndexPage.js
@@ -24,6 +24,7 @@ const WebhooksIndexPage = () => {
   const search = useSelector(selectSearch);
 
   const [toDelete, setToDelete] = useState({});
+  const [toTest, setToTest] = useState({});
   const [toEdit, setToEdit] = useState(0);
 
   const {
@@ -55,6 +56,8 @@ const WebhooksIndexPage = () => {
           setToDelete={setToDelete}
           toEdit={toEdit}
           setToEdit={setToEdit}
+          toTest={toTest}
+          setToTest={setToTest}
           reloadWithSearch={query => dispatch(reloadWithSearch(query))}
         />
       </TableIndexPage>

--- a/webpack/ForemanWebhooks/Routes/Webhooks/constants.js
+++ b/webpack/ForemanWebhooks/Routes/Webhooks/constants.js
@@ -18,3 +18,4 @@ export const WEBHOOK_EVENTS_API_REQUEST_KEY = 'WEBHOOK_EVENTS';
 export const WEBHOOK_CREATE_MODAL_ID = 'webhookCreateModal';
 export const WEBHOOK_EDIT_MODAL_ID = 'webhookEditModal';
 export const WEBHOOK_DELETE_MODAL_ID = 'webhookDeleteModal';
+export const WEBHOOK_TEST_MODAL_ID = 'webhookTestModal';

--- a/webpack/__mocks__/foremanReact/components/common/ActionButtons/ActionButtons.js
+++ b/webpack/__mocks__/foremanReact/components/common/ActionButtons/ActionButtons.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const ActionButtons = () => <div />;


### PR DESCRIPTION
Here is a quick demo with proxy being down/up in case the webhook is configured to use shellhooks:
![Peek 2023-03-27 13-13](https://user-images.githubusercontent.com/32508194/227926424-3718f0b2-d64f-4ff4-a6ad-ddbf5e54dda9.gif)

Although now I think it's better to enable the `test` button even if a webhook is disabled...

UPD: Needs https://github.com/theforeman/foreman/pull/9666. Otherwise it's spamming 
![ScreenShot-1679911317681](https://user-images.githubusercontent.com/32508194/227927528-6bb580bc-0bc5-413a-9b0a-8e270e74b29e.png)
in browser's console :/

UPD2: It would be awesome to make test fire use the actually attached template, but it's not possible until https://github.com/theforeman/foreman_webhooks/pull/38 is re-implemented. We could try to re-open that approach or create a different. I though about registering object type for event, but it would probably require rewriting the way we register event names :/ Or we could add this alongside, but I'm afraid we would duplicate registration process a bit. The new registration would allow us to register object type for event as well as a custom label for the event instead of automatically generated, which can be quite verbose in case of `Action` based events.