### PR TITLE
Fixes #37667 - Provide meaningful error message on org/loc mismatch

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -130,6 +130,7 @@ class Webhook < ApplicationRecord
   end
 
   def rendered_payload(event_name, payload)
+    raise ::Foreman::Exception.new(N_("Webhook template not found while firing webhook '%s'. Possible organization/location mismatch in the webhook template?"), name) if webhook_template.nil?
     webhook_template.render(variables: variables(event_name, payload))
   end
 

--- a/app/subscribers/foreman_webhooks/event_subscriber.rb
+++ b/app/subscribers/foreman_webhooks/event_subscriber.rb
@@ -4,6 +4,8 @@ module ForemanWebhooks
   class EventSubscriber < ::Foreman::BaseSubscriber
     def call(event)
       ::Webhook.deliver(event_name: event.name, payload: event.payload)
+    rescue ::Foreman::Exception => e
+      Rails.logger.error e.message
     end
   end
 end


### PR DESCRIPTION
Added meaningful error message when webhook template fails to render due to organization/location mismatch.