### PR TITLE
Fixes #38176 - Make payload signature less strict

### DIFF
--- a/app/lib/foreman_webhooks/renderer/scope/webhook_template.rb
+++ b/app/lib/foreman_webhooks/renderer/scope/webhook_template.rb
@@ -21,14 +21,17 @@ module ForemanWebhooks
         end
 
         apipie :method, 'Creates final payload' do
-          required :hash, Hash, 'Key=value object with with data that should be present in payload'
+          optional :hash, Hash, 'Key:value object with with data that should be present in payload', default: {}
           keyword :with_defaults, [true, false], 'If set to true, adds default entries to the payload', default: true
+          kwlist :kwargs, 'Additional key:value pairs that should be added to the payload'
           returns String, 'JSON string with the final payload'
           example 'payload({ id: @object.id, name: @object.name }) #=> ' \
                   '"{ "id": 1, "name": "host.example.com", "context": { ... }, ' \
                   '"event_name": "host_created.event.foreman" }"'
         end
-        def payload(hash, with_defaults: true)
+        def payload(hash = {}, with_defaults: true, **kwargs)
+          raise ArgumentError, 'The first argument must be either a hash or a comma-separated list with key:value pairs' unless hash.is_a?(Hash)
+          hash.merge!(kwargs)
           hash.merge!(@defaults) if with_defaults
           hash.to_json
         end


### PR DESCRIPTION
This is mostly a workaround, this should be solved in either safemode or ruby_parser or ruby2ruby libraries. More details in the https://projects.theforeman.org/issues/38176 issue.