### PR TITLE
Fixes #39175 - Unlock a clone of webhook template

### DIFF
--- a/app/controllers/api/v2/webhook_templates_controller.rb
+++ b/app/controllers/api/v2/webhook_templates_controller.rb
@@ -76,8 +76,11 @@ module Api
       param :id, :identifier, required: true
       param_group :webhook_template_clone, as: :create
       def clone
-        @webhook_template = @webhook_template.dup
+        original = @webhook_template
+        @webhook_template = original.dup
+        @webhook_template.cloned_from = original
         @webhook_template.name = params[:webhook_template][:name]
+        @webhook_template.locked = false
         process_response @webhook_template.save
       end
 

--- a/test/controllers/api/v2/webhook_templates_controller_test.rb
+++ b/test/controllers/api/v2/webhook_templates_controller_test.rb
@@ -168,13 +168,16 @@ class Api::V2::WebhookTemplatesControllerTest < ActionController::TestCase
   end
 
   test 'should clone template' do
-    original_webhook_template = FactoryBot.create(:webhook_template)
+    original_webhook_template = FactoryBot.create(:webhook_template, locked: true)
     post :clone, params: { id: original_webhook_template.to_param,
                            webhook_template: { name: 'MyClone' } }
     assert_response :success
     template = ActiveSupport::JSON.decode(@response.body)
     assert_equal(template['name'], 'MyClone')
     assert_equal(template['template'], original_webhook_template.template)
+    refute_equal(template['id'], original_webhook_template.id, 'Clone ID different from original')
+    assert_equal(template['cloned_from_id'], original_webhook_template.id)
+    assert_equal(template['locked'], false)
     refute_equal(template['id'], original_webhook_template.id)
   end
 


### PR DESCRIPTION
Cloning a webhook template resulted in a clone being locked. It should be unlocked. Fixed by setting locked=false before saving.